### PR TITLE
feat(protocol): implementação do Fish Net Protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,18 +262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
-name = "client"
-version = "0.1.0"
-dependencies = [
- "async-channel",
- "async-dup",
- "clap",
- "owo-colors",
- "rand",
- "smol",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +318,19 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fishnet"
+version = "0.1.0"
+dependencies = [
+ "async-channel",
+ "async-dup",
+ "clap",
+ "owo-colors",
+ "rand",
+ "regex",
+ "smol",
+]
 
 [[package]]
 name = "futures-core"
@@ -388,6 +398,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -499,6 +515,35 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ async-dup = "1.2.4"
 clap = { version = "4.5.13", features = ["derive"] }
 rand = "0.9.2"
 owo-colors = "4.2.2"
+regex = "1.11.3"

--- a/src/fishnet_server/mod.rs
+++ b/src/fishnet_server/mod.rs
@@ -3,4 +3,3 @@ mod server;
 mod protocol;
 
 pub use server::PeerServer;
-pub use protocol::FNP;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ mod ui;
 mod fishnet_server;
 
 
-/// Endereço de IP do primeiro peer
+/// Endereço de IP do primeiro peer: 127.0.0.1:6000
 const DEFAULT_HOST: ([u8; 4], u16) = ([127, 0, 0, 1], 6000);
 
 

--- a/src/ui/cli.rs
+++ b/src/ui/cli.rs
@@ -33,10 +33,7 @@ impl Args {
 
 /// Parseando e validando os endereços
 fn parse_addr(s: &str) -> Result<SocketAddr, String> {
-    if let Ok(addr) = s.parse::<SocketAddr>() {
-        return Ok(addr);
-    }
-    Err(format!("Invalid bind/peer address: {}", s))
+    s.parse().map_err(|e| format!("Invalid bind/peer address: {}", e))
 }
 
 


### PR DESCRIPTION
- Parser
- Encoder
- TestCase

Especificação do Fish Net Protocol.
Inspiração do HTTP/1.1 e do SMTP.
 
```
  FNP 1.0;
  REM: (fnp://127.0.0.1:6000);
  DEST: (*|fnp://129.0.0.1:4848);
  CMD: (Message|Inspection|InvetoryShowcase|Broadcast|TradeOffer|TradeConfirm);
  [Content|Invetory|Offer|OfferResponse]: *;
  Content: "text"
  Invetory: fish|10, fish2|100;
  Offer: fish1|10 > fish2|10;
  OfferResponse: true|false;
```